### PR TITLE
원격 서버 관리 페이지 추가

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,11 +8,13 @@ from views.user.dashboard_view import dashboard_blueprint
 from views.user.linux_command_assistant_view import linux_command_assistant_blueprint
 from views.admin.dashboard_view import admin_dashboard_blueprint
 from views.admin.manage.user_view import user_manage_blueprint
+from views.admin.manage.remote_view import remote_servers_blueprint
 from views.API.account.signup_api import signup_api_blueprint
 from views.API.account.signin_api import signin_api_blueprint
 from views.API.account.get_users_api import get_users_api_blueprint
 from views.API.linux_command_assistant.prompt import prompt_api_blueprint
 from views.API.linux_command_assistant.terminal import terminal_socket_blueprint
+from views.API.remote.remote_servers_api import remote_api_blueprint
 from config import app
 
 app = Flask(__name__)
@@ -35,6 +37,8 @@ app.register_blueprint(linux_command_assistant_blueprint)
 app.register_blueprint(admin_dashboard_blueprint)
 # User Manage Blueprint 경로: /views/admin/manage/user_view.py
 app.register_blueprint(user_manage_blueprint)
+# Remote Servers Manage Blueprint 경로: /views/admin/manage/remote_view.py
+app.register_blueprint(remote_servers_blueprint)
 
 
 """ API view blueprint """
@@ -48,6 +52,8 @@ app.register_blueprint(get_users_api_blueprint)
 app.register_blueprint(prompt_api_blueprint)
 
 app.register_blueprint(terminal_socket_blueprint)
+# Remote Server Blueprint 경뢰 /views/API/remote/remote_servers_api.py
+app.register_blueprint(remote_api_blueprint)
 
 
 # app.py

--- a/templates/admin/manage/remote.html
+++ b/templates/admin/manage/remote.html
@@ -1,0 +1,220 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        {% include '/template/head.html' %}
+        <title>Dashboard - Jirangobie</title>
+    </head>
+    <body>
+    
+        <div class="sidebar">
+            {% include '/template/admin_sidebar.html' %}
+        </div>
+        
+        <div class="main_grid">
+            <div class="top-content">
+                {% include '/template/header.html' %}
+            </div>
+            <div class="bottom-content">
+                <!-- Remote Server Info Section Start -->
+                <div class="shadow-sm p-3 mb-5 bg-body rounded" style="margin: 1rem 2rem 0 2rem; ">
+                    <table class="table caption-top">
+                        <caption>Remote Server data table</caption>
+                        <thead>
+                            <tr style="font-size: 15px;">
+                                <th scope="col">#</th>
+                                <th>서버 이름</th>
+                                <th>보안 수준</th>
+                                <th>접근 권한</th>
+                                <th>운영체제</th>
+                                <th>버전</th>
+                                <th>IP 주소</th>
+                                <th>저장된 스크립트</th>
+                                <th>마지막 점검일</th>
+                            </tr>
+                        </thead>
+                        <tbody id="usersTable" class="table-group-divider" style="font-size: small;">
+                            
+                        </tbody>
+                    </table>
+                    <div style="display: flex; justify-content: space-between;">
+                        <div class="pagination-info" style="font-size:13px; color:#696969; margin-top:.3rem;">Showing <span id="startEntry">0</span> to <span id="endEntry">0</span> of <span id="totalEntries">0</span> entries</div>
+                        <div class="pagination" style="margin-right: .4rem;"></div>
+                    </div>
+                    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#add-Remote-Server" style="border-radius: unset;">Add remote server</button>
+                </div>
+                <!-- Remote Server Info Section End -->
+            </div>
+        </div>
+
+        <!-- Add Remote Server Modal Section Start -->
+        <div class="modal fade" id="add-Remote-Server" tabindex="-1" aria-labelledby="add-Remote-Server" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="add-Remote-Server-Title-Label">Add remote server</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                    </div>
+                    <div class="modal-body">
+                        <form>
+                            <div class="">
+                                <label class="col-form-label">서버 이름</label>
+                                <input type="text" class="form-control" id="server_name">
+                            </div>
+                            <div class="">
+                                <label class="col-form-label">접근 권한</label>
+                                <input type="text" class="form-control" id="access_role">
+                            </div>
+                            <div class="">
+                                <label class="col-form-label">IP 주소</label>
+                                <input type="text" class="form-control" id="server_ip">
+                            </div>
+                            <div class="">
+                                <label class="col-form-label">SSH 계정명</label>
+                                <input type="text" class="form-control" id="username">
+                            </div>
+                            <div class="">
+                                <label class="col-form-label">패스워드</label>
+                                <input type="text" class="form-control" id="password">
+                            </div>
+                        </form>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button type="submit" id="connectButton" class="btn btn-primary">Connect</button>
+                    </div>
+                </div>
+                <!-- Loading... Spinner Start -->
+                <div id="overlay" style="display:none; position:absolute; top:0; left:0; width:100%; height:100%; background-color: rgba(0, 0, 0, 0.5); z-index:1000;"></div>
+                    <div class="spinner-border text-primary" role="status" id="loadingSpinner" style="display:none; position:absolute; top:50%; left:50%; transform:translate(-50%, -50%); z-index:2000;">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+                <!-- Loading... Spinner End -->
+            </div>
+        </div>
+        <!-- Add Remote Server Modal Section End -->
+        
+        {% include '/template/foot.html' %}
+        <script>
+            function createPaginationButtons(totalPages, currentPage) {
+                let buttons = '<nav aria-label="Page navigation"><ul class="pagination pagination-sm">';
+
+                // 이전 페이지 버튼
+                if (currentPage > 1) {
+                    buttons += `<li class="page-item"><a href="#" class="page-link prev" data-page="${currentPage - 1}">Previous</a></li>`;
+                } else {
+                    buttons += `<li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">Previous</a></li>`;
+                }
+
+                // 페이지 번호 버튼
+                for (let i = 1; i <= totalPages; i++) {
+                    if (i === currentPage) {
+                        buttons += `<li class="page-item active" aria-current="page"><a href="#" class="page-link page-number" data-page="${i}">${i}</a></li>`;
+                    } else {
+                        buttons += `<li class="page-item"><a href="#" class="page-link page-number" data-page="${i}">${i}</a></li>`;
+                    }
+                }
+
+                // 다음 페이지 버튼
+                if (currentPage < totalPages) {
+                    buttons += `<li class="page-item"><a href="#" class="page-link next" data-page="${currentPage + 1}">Next</a></li>`;
+                } else {
+                    buttons += `<li class="page-item disabled"><a class="page-link" href="#" tabindex="-1" aria-disabled="true">Next</a></li>`;
+                }
+
+                buttons += '</ul></nav>';
+
+                $(".pagination").html(buttons);
+            }
+
+            $(document).ready(function() {
+                var items_per_page = 10;
+                function loadPage(pageNumber) {
+                    $.post("/API/remote/get-servers", { page: pageNumber }, function(data) {
+                        console.log(data);
+
+                        var tableContent = "";
+                        var index = 1 + (pageNumber - 1) * 10;
+                        for (var serverId in data.servers) {
+                            var server = data.servers[serverId];
+                            tableContent += "<tr>";
+                            tableContent += "<td>" + index + "</td>";
+                            tableContent += "<td>" + server.server_name + "</td>";
+                            tableContent += "<td>" + server.security_score + "</td>";
+                            tableContent += "<td>" + server.access_role + "</td>";
+                            tableContent += "<td>" + server.os + "</td>";
+                            tableContent += "<td>" + server.version + "</td>";
+                            tableContent += "<td>" + server.ip_address + "</td>";
+                            tableContent += "<td>" + server.saved_script + "</td>";
+                            tableContent += "<td>" + server.last_scan + "</td>";                        
+                            tableContent += "</tr>";
+                            index++;
+                        }
+                        var startEntry = (pageNumber - 1) * items_per_page + 1;
+                        var endEntry = Math.min(pageNumber * items_per_page, data.total_servers);
+                        $("#startEntry").text(startEntry);
+                        $("#endEntry").text(endEntry);
+                        $("#totalEntries").text(data.total_servers);
+                        $("#usersTable").html(tableContent);
+                        createPaginationButtons(data.total_pages, pageNumber);
+
+                    }).fail(function() {
+                        console.error("요청에 실패했습니다.");
+                    });
+                }loadPage(1); // 초기 페이지 로딩
+
+                // 페이지네비게이션 버튼 클릭 이벤트
+                $(document).on("click", ".page-number, .prev, .next", function(e) {
+                    e.preventDefault();
+                    const pageNumber = $(this).data("page");
+                    loadPage(pageNumber);
+                });
+            });
+
+
+        // add remote server modal js
+        $(document).ready(function () {
+            document.getElementById("connectButton").addEventListener("click", function (e) { // 'e'를 매개변수로 추가
+                e.preventDefault(); // Prevent the default form submit action
+
+                var serverName = $('#server_name').val();
+                var accessRole = $('#access_role').val();
+                var serverIp = $('#server_ip').val();
+                var userName = $('#username').val();
+                var password = $('#password').val();
+
+                $('#loadingSpinner').show();
+                $('#overlay').show();
+
+                $.ajax({
+                    type: "POST",
+                    url: "/API/remote/add-remote-server",
+                    data: {
+                        server_name: serverName,
+                        access_role: accessRole,
+                        server_ip: serverIp,
+                        username: userName,
+                        password: password
+                    },
+                    success: function (response) {
+                        $("#loadingSpinner").hide();
+                        $('#overlay').hide();
+                        console.log(response);
+
+                        if (response['status'] == 'success') {
+                            alert(response['message']);
+                        } else {
+                            alert('Error: ' + response['message']);
+                        }
+                    },
+                    error: function (error) {
+                        // Handle error
+                        $("#loadingSpinner").hide();
+                        $('#overlay').hide();
+                        alert('Error')
+                    }
+                });
+            });
+        });
+        </script>
+    </body>
+</html>

--- a/templates/template/admin_sidebar.html
+++ b/templates/template/admin_sidebar.html
@@ -28,7 +28,7 @@
             </a>
         </li>
         <li>
-            <a href="#" class="nav-link text-white">
+            <a href="../remote_servers" class="nav-link text-white">
                 <img src="{{ url_for('static', filename='images/icons/icons8-remote-50.png') }}" width="16"
                     height="16" class="d-inline-block align-middle" alt="">
                 Remote servers

--- a/templates/user/linux_command_assistant.html
+++ b/templates/user/linux_command_assistant.html
@@ -109,7 +109,6 @@
                     message: message
                 })
             })
-            .then(handleAPIResponse)
             .then(response => {
                 const reader = response.body.getReader();
                 const decoder = new TextDecoder();

--- a/views/API/remote/remote_servers_api.py
+++ b/views/API/remote/remote_servers_api.py
@@ -1,0 +1,54 @@
+from flask import Blueprint, request, jsonify
+from ..db_utils import mongodb_connect
+import re
+import os
+import base64
+from ...API.account.account_verification_api import check_verification
+
+
+remote_api_blueprint = Blueprint('remote_api', __name__, url_prefix='/API/remote')
+
+db = mongodb_connect()
+
+# This Route: /API/remote/get-servers
+@remote_api_blueprint.route('/get-servers', methods=['POST'])
+@check_verification(['admin'])
+def get_servers():
+    page = int(request.form.get('page', 1))
+    items_per_page = 10
+    skip = (page - 1) * items_per_page
+    
+    total_servers = db.remote.count_documents({})
+    total_pages = -(-total_servers // items_per_page)  # 올림 나눗셈
+
+    servers = {server['_id']: server for server in db.remote.find().skip(skip).limit(items_per_page)}
+    filtered_servers = {}
+    for server_id, server_info in servers.items():
+        filtered_servers[str(server_id)] = {
+            'server_name': server_info['server_name'],
+            'security_score': server_info['security_score'],
+            'access_role': server_info['access_role'],
+            'os': server_info['os'],
+            'version': server_info['version'],
+            'ip_address' : server_info['ip_address'],
+            'saved_script' : server_info['saved_script'],
+            'last_scan' : server_info['last_scan'],
+        }
+    print("servers:",filtered_servers)
+
+    return jsonify({"status" : "success", "message": "원격 서버 조회 성공", "servers": filtered_servers, "total_pages": total_pages, "total_servers": total_servers}), 201
+
+# This Route: /API/remote/get-servers
+@remote_api_blueprint.route('/add-remote-server', methods=['POST'])
+@check_verification(['admin'])
+def add_remote_server():
+    """
+    TODO
+    1. ajax를 통해 받은 값 변수로 저장
+    2. 해당 정보를 통해 paramiko ssh 연결
+    3. ssh 채널로 서버 정보를 얻어옴(/etc/issue)
+    4. 성공시 DB에 값들 저장
+    4.1. 실패시 해당 에러 반환
+    """
+
+    return jsonify({"status" : "success", "message": "원격 서버 추가 성공"}), 201

--- a/views/admin/manage/remote_view.py
+++ b/views/admin/manage/remote_view.py
@@ -1,0 +1,10 @@
+from flask import Blueprint, render_template
+from ...API.account.account_verification_api import check_verification
+
+remote_servers_blueprint = Blueprint('remote_servers', __name__, url_prefix='/jiranistrator/remote_servers')
+# user manage root route: /jiranistrator/remote_servers
+
+@remote_servers_blueprint.route('/', methods=['GET', 'POST'])
+@check_verification(['admin'])
+def user_manage():
+    return render_template('admin/manage/remote.html', page_title="관리자/원격서버관리")


### PR DESCRIPTION
1. app.py: 원격 서버 관리 페이지, API 블루프린트 등록
2. templates/admin/manage/remote.html: 원격 서버 관리 페이지 추가(기본 틑만 적용)
3. templates/user/linux_command_assistant.html: 페이지 접근 권한 검사 로직 제거(버그 발생)
4. views/admin/manage/remote_view.py: 원격 서버 관리 페이지 라우트 생성
5. views/API/remote/remote_servers_api.py: 원격 서버 정보 획득 API 추가, 원격 서버 추가 API 스켈레톤 코드 작성
6. templates/template/admin_sidebar.html: 원격 서버 관리 페이지 href 적용